### PR TITLE
style add custom theme

### DIFF
--- a/components/common/button-orange.tsx
+++ b/components/common/button-orange.tsx
@@ -1,0 +1,37 @@
+import { Button, ButtonProps } from "@chakra-ui/react";
+import React from "react";
+
+type ButtonOrangeProps = {
+  children: React.ReactNode;
+  props: ButtonProps;
+};
+
+export function ButtonOrange({ children, props }: ButtonOrangeProps) {
+  return (
+    <Button
+      {...props}
+      lineHeight="1.2"
+      transition="all 0.2s cubic-bezier(.08,.52,.52,1)"
+      fontSize="14px"
+      fontWeight="semibold"
+      bg="orange.400"
+      color="gray.50"
+      _hover={{ bg: "orange.500" }}
+      _active={{
+        bg: "orange.300",
+        transform: "scale(0.98)",
+        // borderColor: "#bec3c9",
+      }}
+      _focus={{
+        boxShadow:
+          "0 0 1px 2px rgba(88, 144, 255, .75), 0 1px 1px rgba(0, 0, 0, .15)",
+      }}
+    // variant="solid" borderColor="#ccd0d5"
+    // as="button" height="24px"
+    // border="1px" px="8px"
+    // borderRadius="2px"
+    >
+      {children}
+    </Button>
+  );
+}

--- a/components/common/button-orange.tsx
+++ b/components/common/button-orange.tsx
@@ -1,37 +1,74 @@
-import { Button, ButtonProps } from "@chakra-ui/react";
+import { As, Button, ButtonProps, forwardRef, Tooltip } from "@chakra-ui/react";
 import React from "react";
 
-type ButtonOrangeProps = {
+export type ButtonOrangeProps = {
   children: React.ReactNode;
   props: ButtonProps;
+  onClick?: () => void;
+  isDisabled?: boolean;
+  tooltipLabel?: string;
 };
 
-export function ButtonOrange({ children, props }: ButtonOrangeProps) {
-  return (
-    <Button
-      {...props}
-      lineHeight="1.2"
-      transition="all 0.2s cubic-bezier(.08,.52,.52,1)"
-      fontSize="14px"
-      fontWeight="semibold"
-      bg="orange.400"
-      color="gray.50"
-      _hover={{ bg: "orange.500" }}
-      _active={{
-        bg: "orange.300",
-        transform: "scale(0.98)",
-        // borderColor: "#bec3c9",
-      }}
-      _focus={{
-        boxShadow:
-          "0 0 1px 2px rgba(88, 144, 255, .75), 0 1px 1px rgba(0, 0, 0, .15)",
-      }}
-    // variant="solid" borderColor="#ccd0d5"
-    // as="button" height="24px"
-    // border="1px" px="8px"
-    // borderRadius="2px"
-    >
-      {children}
-    </Button>
-  );
-}
+/**
+ * A customizable orange button component with a tooltip that can be used throughout the app.
+ *
+ * The `ButtonOrange` component uses `forwardRef` to pass a ref to the underlying
+ * Button component and separates its own props from the Button props.
+ *
+ * It also adds a Tooltip component for accessibility. This provides flexibility
+ * for the caller to customize the Button component based on their needs.
+ * Since function components cannot be given refs directly, forwardRef is used
+ * to pass the ref to the underlying Button component.
+ *
+ * This allows us to access the underlying DOM node of the Button component
+ * for imperative actions, such as focusing the button, in the parent
+ * component that uses the ButtonOrange component.
+ *
+ * @param {Object} props - The component props.
+ * @returns {React.ReactElement} - A React component.
+ * @param {React.ReactNode} props.children - The content to be rendered inside the button.
+ * @param {Object} props.props - Additional props to be passed to the button component.
+ * @param {() => void} [props.onClick] - The click handler for the button.
+ * @param {boolean} [props.isDisabled] - Determines whether the button is disabled or not.
+ * @param {string} [props.tooltipLabel] - The text for the tooltip that appears on hover.
+ */
+export const ButtonOrange = forwardRef<ButtonOrangeProps, As<any>>(
+  (
+    { children, props, onClick, isDisabled, tooltipLabel }: ButtonOrangeProps,
+    ref: React.ForwardedRef<any>
+  ) => {
+    /**
+     * Handles the click event on the button.
+     */
+    const handleOnClick = () => {
+      if (onClick) {
+        onClick();
+      }
+    };
+
+    return (
+      <Tooltip label={tooltipLabel}>
+        <Button
+          ref={ref}
+          {...props}
+          lineHeight="1.2"
+          transition="all 0.2s cubic-bezier(.08,.52,.52,1)"
+          fontSize="14px"
+          fontWeight="semibold"
+          isDisabled={isDisabled}
+          bg="orange.400"
+          color="gray.50"
+          onClick={handleOnClick}
+          _hover={{ bg: "orange.500" }}
+          _active={{ bg: "orange.300", transform: "scale(0.98)" }} // borderColor: "#bec3c9",
+          _focus={{
+            boxShadow:
+              "0 0 1px 2px rgba(88, 144, 255, .75), 0 1px 1px rgba(0, 0, 0, .15)",
+          }}
+        >
+          {children}
+        </Button>
+      </Tooltip>
+    );
+  }
+);

--- a/components/common/button-orange.tsx
+++ b/components/common/button-orange.tsx
@@ -51,14 +51,14 @@ export const ButtonOrange = forwardRef<ButtonOrangeProps, As<any>>(
         <Button
           ref={ref}
           {...props}
+          onClick={handleOnClick}
+          isDisabled={isDisabled}
           lineHeight="1.2"
           transition="all 0.2s cubic-bezier(.08,.52,.52,1)"
           fontSize="14px"
           fontWeight="semibold"
-          isDisabled={isDisabled}
           bg="orange.400"
           color="gray.50"
-          onClick={handleOnClick}
           _hover={{ bg: "orange.500" }}
           _active={{ bg: "orange.300", transform: "scale(0.98)" }} // borderColor: "#bec3c9",
           _focus={{

--- a/components/editor/editor.tsx
+++ b/components/editor/editor.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Box, Grid, Stack } from "@chakra-ui/react";
+import { Box, Divider, Grid, SimpleGrid, Stack, StackDivider } from "@chakra-ui/react";
 
 import Markdown from "@/components/markdown/markdown";
 import Preview from "@/components/preview/preview";
@@ -8,10 +8,10 @@ import Preview from "@/components/preview/preview";
 export default function Editor() {
   return (
     <Stack id="editor">
-      <Grid w="full" templateColumns={{ base: "50vw 50vw" }}>
+      <SimpleGrid w="full" gridTemplateColumns="50vw 50vw" >
         <Markdown />
         <Preview />
-      </Grid>
+      </SimpleGrid>
     </Stack>
   );
 }

--- a/components/icons/icons.tsx
+++ b/components/icons/icons.tsx
@@ -116,3 +116,35 @@ export function CloseIcon(props: IconProps) {
     </svg>
   );
 }
+
+export function SunIcon(props: IconProps) {
+  return (
+    <svg
+      {...props}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      width="17"
+      height="17"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor" className="sun-icon">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />
+    </svg>
+  );
+}
+
+export function MoonIcon(props: IconProps) {
+  return (
+    <svg
+      {...props}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      width="17"
+      height="17"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor" className="sun-icon">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" />
+    </svg>
+  );
+}

--- a/components/markdown/markdown-body.tsx
+++ b/components/markdown/markdown-body.tsx
@@ -18,6 +18,7 @@ import {
 import { INote } from "@/types/inote";
 import { nanoid } from "nanoid";
 import { getTimestamp } from "@/utils/get-timestamp";
+import { mode } from "@chakra-ui/theme-tools";
 
 export default function MarkdownBody() {
   const { state, dispatch } = useContext(AppContext);
@@ -63,13 +64,25 @@ export default function MarkdownBody() {
         id="markdownEditor"
         boxSize={"full"}
         data-testid="markdownArea"
+        _hover={{
+          borderColor: mode("gray.200", "gray.50"),
+          // borderTopColor: "transparent !important",
+        }}
+        _focusVisible={{
+          borderColor: mode("orange.200", "orange.200"),
+          // borderTopColor: "transparent !important",
+        }}
+        outlineColor="transparent"
+        borderColor={"transparent"}
+        rounded="none"
         value={activeNote?.content ? activeNote.content : ""}
         onChange={updateContent}
         w="full"
         p="4"
+        // ms="px"
         fontFamily="monospace"
         placeholder="Markdown is awesome!!"
-        fontSize={["2xs", "xs"]}
+        fontSize={["xs", "xs"]}
       />
     </>
   );

--- a/components/markdown/markdown-body.tsx
+++ b/components/markdown/markdown-body.tsx
@@ -69,7 +69,7 @@ export default function MarkdownBody() {
           // borderTopColor: "transparent !important",
         }}
         _focusVisible={{
-          borderColor: mode("orange.200", "orange.200"),
+          borderColor: mode("orange.200", "orange.100"),
           // borderTopColor: "transparent !important",
         }}
         outlineColor="transparent"

--- a/components/markdown/markdown-body.tsx
+++ b/components/markdown/markdown-body.tsx
@@ -81,6 +81,7 @@ export default function MarkdownBody() {
         p="4"
         // ms="px"
         fontFamily="monospace"
+        className="markdown-editor"
         placeholder="Markdown is awesome!!"
         fontSize={["xs", "xs"]}
       />

--- a/components/markdown/markdown-header.tsx
+++ b/components/markdown/markdown-header.tsx
@@ -23,7 +23,6 @@ export default function MarkdownHeader() {
       py="3"
       _dark={{ bg: "whiteAlpha.100" }}
       bg="blackAlpha.100"
-    // minHeight={{ base: "10", md: "10" }}
     >
       <Flex align="center" justify="space-between">
         <Box fontSize="sm" letterSpacing="widest" opacity="0.75" textTransform="uppercase">markdown</Box>

--- a/components/markdown/markdown-header.tsx
+++ b/components/markdown/markdown-header.tsx
@@ -9,6 +9,7 @@ import {
 } from "@chakra-ui/react";
 import React, { useContext, useState } from "react";
 import { CopyIcon, ViewIcon, ViewOffIcon } from "@chakra-ui/icons";
+
 export default function MarkdownHeader() {
   const { state, dispatch } = useContext(AppContext);
 
@@ -18,18 +19,20 @@ export default function MarkdownHeader() {
 
   return (
     <Box
-      minHeight={{ base: "10", md: "10" }}
+      px="4"
+      py="3"
       _dark={{ bg: "whiteAlpha.100" }}
       bg="blackAlpha.100"
+    // minHeight={{ base: "10", md: "10" }}
     >
       <Flex align="center" justify="space-between">
-        <Box textTransform="uppercase">markdown</Box>
-
+        <Box fontSize="sm" letterSpacing="widest" opacity="0.75" textTransform="uppercase">markdown</Box>
         <IconButton
           icon={<ViewIcon />}
           onClick={handleOnClick}
-          // display={{ md: "none" }}
           opacity={{ md: 0 }}
+          variant="link"
+          size="sm"
           pointerEvents={{ md: "none" }}
           aria-label="Toggle markdown preview"
         />

--- a/components/markdown/markdown.tsx
+++ b/components/markdown/markdown.tsx
@@ -10,6 +10,7 @@ export default function Markdown() {
   return (
     <Box
       id="markdown"
+      className="markdown-editor"
       borderInlineEndWidth="thin"
       borderInlineEndColor="blackAlpha.200"
       _dark={{ borderInlineEndColor: "whiteAlpha.500" }}

--- a/components/markdown/markdown.tsx
+++ b/components/markdown/markdown.tsx
@@ -11,8 +11,8 @@ export default function Markdown() {
     <Box
       id="markdown"
       borderInlineEndWidth="thin"
-      borderInlineEndColor="gray.200"
-      _dark={{ borderInlineEndColor: "gray.50" }}
+      borderInlineEndColor="blackAlpha.200"
+      _dark={{ borderInlineEndColor: "whiteAlpha.500" }}
     >
       <MarkdownHeader />
       <MarkdownBody />

--- a/components/markdown/markdown.tsx
+++ b/components/markdown/markdown.tsx
@@ -4,10 +4,16 @@ import { Box } from "@chakra-ui/react";
 
 import MarkdownBody from "@/components/markdown/markdown-body";
 import MarkdownHeader from "@/components/markdown/markdown-header";
+import { mode } from "@chakra-ui/theme-tools";
 
 export default function Markdown() {
   return (
-    <Box id="markdown">
+    <Box
+      id="markdown"
+      borderInlineEndWidth="thin"
+      borderInlineEndColor="gray.200"
+      _dark={{ borderInlineEndColor: "gray.50" }}
+    >
       <MarkdownHeader />
       <MarkdownBody />
     </Box>

--- a/components/navbar/aside-button.tsx
+++ b/components/navbar/aside-button.tsx
@@ -1,4 +1,4 @@
-import { Button, IconButton, VisuallyHidden } from "@chakra-ui/react";
+import { AspectRatio, Button, IconButton, VisuallyHidden } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { CloseIcon, HamburgerMenuIcon } from "../icons/icons";
 
@@ -15,12 +15,25 @@ export default function AsideButton() {
       <VisuallyHidden>
         {isOpenMenu ? "close sidebar menu" : "open sidebar menu"}
       </VisuallyHidden>
-      <IconButton
-        aria-label="Menu toggle button"
-        onClick={handleToggleSidebar}
-        h="full"
-        icon={isOpenMenu ? <CloseIcon /> : <HamburgerMenuIcon />}
-      />
+
+      <AspectRatio
+
+        ratio={1}>
+
+        <IconButton
+          aria-label="Menu toggle button"
+          onClick={handleToggleSidebar}
+          h="full"
+          bg="gray.50"
+          rounded="none"
+          _hover={{ bg: "orange.400" }}
+          _dark={{
+            bg: "gray.600",
+            _hover: { bg: "orange.400" }
+          }}
+          icon={isOpenMenu ? <CloseIcon /> : <HamburgerMenuIcon />}
+        />
+      </AspectRatio>
     </>
   );
 }

--- a/components/navbar/aside-button.tsx
+++ b/components/navbar/aside-button.tsx
@@ -1,4 +1,9 @@
-import { AspectRatio, Button, IconButton, VisuallyHidden } from "@chakra-ui/react";
+import {
+  AspectRatio,
+  Button,
+  IconButton,
+  VisuallyHidden,
+} from "@chakra-ui/react";
 import React, { useState } from "react";
 import { CloseIcon, HamburgerMenuIcon } from "../icons/icons";
 
@@ -16,21 +21,18 @@ export default function AsideButton() {
         {isOpenMenu ? "close sidebar menu" : "open sidebar menu"}
       </VisuallyHidden>
 
-      <AspectRatio
-
-        ratio={1}>
-
+      <AspectRatio ratio={1}>
         <IconButton
           aria-label="Menu toggle button"
           onClick={handleToggleSidebar}
           h="full"
-          bg="gray.50"
+          // bg="gray.50"
           rounded="none"
+          // _hover={{ bg: "orange.400" }}
+          // _dark={{
+          bg="gray.600"
           _hover={{ bg: "orange.400" }}
-          _dark={{
-            bg: "gray.600",
-            _hover: { bg: "orange.400" }
-          }}
+          // }}
           icon={isOpenMenu ? <CloseIcon /> : <HamburgerMenuIcon />}
         />
       </AspectRatio>

--- a/components/navbar/logo.tsx
+++ b/components/navbar/logo.tsx
@@ -11,7 +11,15 @@ export default function Logo() {
       borderInlineEndColor="blackAlpha.400"
       h="full"
     >
-      <Text fontWeight="bold" letterSpacing="0.5ch" textTransform="uppercase">markdown</Text>
+      <Text
+        fontWeight="bold"
+        letterSpacing="0.5ch"
+        textTransform="uppercase"
+        lineHeight="none"
+        mb="0"
+      >
+        markdown
+      </Text>
     </Box>
   );
 }

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -10,8 +10,8 @@ import NoteTitle from "@/components/navbar/note-title";
 export default function Navbar() {
   return (
     <>
-      <Box>
-        <chakra.header bg="gray.50" _dark={{ bg: "gray.700" }}>
+      <Box bg="gray.700" color="gray.100">
+        <chakra.header>
           <Grid
             alignItems="center"
             gridTemplateColumns={{

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -17,7 +17,6 @@ export default function Navbar() {
             gridTemplateColumns={{
               base: "56px 1fr",
               md: "72px 1fr",
-              xl: "auto 1fr 20px 150px",
             }}
           >
             <AsideButton />

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -11,7 +11,7 @@ export default function Navbar() {
   return (
     <>
       <Box>
-        <chakra.header shadow={"xl"} bg="gray.50" _dark={{ bg: "gray.700" }}>
+        <chakra.header bg="gray.50" _dark={{ bg: "gray.700" }}>
           <Grid
             alignItems="center"
             gridTemplateColumns={{

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -11,7 +11,7 @@ export default function Navbar() {
   return (
     <>
       <Box>
-        <chakra.header bg="gray.50" _dark={{ bg: "gray.700" }}>
+        <chakra.header shadow={"xl"} bg="gray.50" _dark={{ bg: "gray.700" }}>
           <Grid
             alignItems="center"
             gridTemplateColumns={{

--- a/components/navbar/note-save.tsx
+++ b/components/navbar/note-save.tsx
@@ -1,55 +1,61 @@
 import { ActionType, AppContext } from "@/store/AppContext";
-import {
-  Button,
-  ButtonGroup,
-  chakra,
-  IconButton,
-  Tooltip,
-} from "@chakra-ui/react";
+import { chakra } from "@chakra-ui/react";
 import React, { useContext } from "react";
 import { SaveIcon } from "../icons/icons";
 import { useToast } from "@chakra-ui/react";
 import { ButtonOrange } from "../common/button-orange";
 
+/**
+ * A component to save changes to the active note in the app context
+ */
 export default function NoteSave() {
   const { state, dispatch } = useContext(AppContext);
   const { activeNote } = state;
   const toast = useToast();
-
+  /**
+   * Handle click on the save button
+   */
   function handleOnClick() {
     if (!activeNote) {
       return;
     }
+
+    if (activeNote.content.trim().length === 0){
+    toast({
+      title: "Nothing to save",
+      status: "info",
+    });
+    return;
+
+    }
+
     dispatch({ type: ActionType.SAVE_CHANGES, note: activeNote });
-    // description: `${activeNote.title} saved`,
+
     toast({
       title: "Saved changes",
       status: "success",
-      duration: 3000,
-      isClosable: true,
     });
   }
 
   return (
-    <Tooltip label="save changes">
-      <ButtonOrange
-        aria-label="Save changes"
-        data-testid="saveButton"
-        props={{
-          onClick: handleOnClick,
-          textTransform: "capitalize",
-          alignItems: "center",
-          isDisabled: activeNote ? false : true,
-          w: "fit-content",
-        }}
-      >
-        <chakra.div aria-hidden="true" pe={{ md: "2" }}>
-          <SaveIcon aria-hidden="true" />
-        </chakra.div>
-        <chakra.span display={{ base: "none", md: "inline-block" }}>
-          save changes
-        </chakra.span>
-      </ButtonOrange>
-    </Tooltip>
+    <ButtonOrange
+      data-testid="saveButton"
+      aria-label="Save changes"
+      tooltipLabel={"save changes"}
+      onClick={handleOnClick}
+      isDisabled={activeNote ? false : true}
+      props={{
+        w: "fit-content",
+        textTransform: "capitalize",
+        alignItems: "center",
+      }}
+    >
+      <chakra.div aria-hidden="true" pe={{ md: "2" }}>
+        <SaveIcon aria-hidden="true" />
+      </chakra.div>
+      <chakra.span display={{ base: "none", md: "inline-block" }}>
+        save changes
+      </chakra.span>
+    </ButtonOrange>
   );
 }

--- a/components/navbar/note-save.tsx
+++ b/components/navbar/note-save.tsx
@@ -9,6 +9,7 @@ import {
 import React, { useContext } from "react";
 import { SaveIcon } from "../icons/icons";
 import { useToast } from "@chakra-ui/react";
+import { ButtonOrange } from "../common/button-orange";
 
 export default function NoteSave() {
   const { state, dispatch } = useContext(AppContext);
@@ -31,16 +32,16 @@ export default function NoteSave() {
 
   return (
     <Tooltip label="save changes">
-      <Button
+      <ButtonOrange
         aria-label="Save changes"
-        onClick={handleOnClick}
         data-testid="saveButton"
-        textTransform="capitalize"
-        alignItems="center"
-        w="fit-content"
-        isDisabled={activeNote ? false : true}
-        bg="orange.400"
-        _dark={{ bg: "orange.400" }}
+        props={{
+          onClick: handleOnClick,
+          textTransform: "capitalize",
+          alignItems: "center",
+          isDisabled: activeNote ? false : true,
+          w: "fit-content",
+        }}
       >
         <chakra.div aria-hidden="true" pe={{ md: "2" }}>
           <SaveIcon aria-hidden="true" />
@@ -48,7 +49,7 @@ export default function NoteSave() {
         <chakra.span display={{ base: "none", md: "inline-block" }}>
           save changes
         </chakra.span>
-      </Button>
+      </ButtonOrange>
     </Tooltip>
   );
 }

--- a/components/navbar/note-title.tsx
+++ b/components/navbar/note-title.tsx
@@ -71,11 +71,21 @@ export default function NoteTitle() {
       alignItems="center"
     >
       <Tooltip
-      // label={ activeNote ? `copy contents of ${activeNote.title.trim()}.md` : "" }
+        placement="bottom"
+        hasArrow
+        gutter={16}
+        // bg="blue.400"
+        arrowSize={15}
+        openDelay={300}
+        label={
+          activeNote ? `copy contents of ${activeNote.title.trim()}.md` : ""
+        }
       >
         <IconButton
-          variant="ghost"
+          variant="solid"
           stroke="gray.300"
+          bg="transparent"
+          _hover={{bg:"blackAlpha.200"}}
           icon={<DocumentIcon aria-hidden="true" />}
           aria-label="copy markdown"
           onClick={handleOnClickCopyMarkdown}
@@ -85,10 +95,11 @@ export default function NoteTitle() {
       <Box ml="2">
         <Hide below="md">
           <chakra.label
+            // _dark={{ color: "whiteAlpha.500" }}
+            // color="blackAlpha.500"
             lineHeight="none"
             fontSize={{ base: "2xs", md: "xs" }}
-            _dark={{ color: "whiteAlpha.500" }}
-            color="blackAlpha.500"
+            color="gray.400"
             textTransform="capitalize"
           >
             document name
@@ -96,7 +107,7 @@ export default function NoteTitle() {
         </Hide>
 
         <Tooltip
-        // label={activeNote ? `rename ${activeNote.title.trim()}.md` : ""}
+          label={activeNote ? `rename ${activeNote.title.trim()}.md` : ""}
         >
           <Input
             data-testid="titleInput"

--- a/components/preview/preview-body.tsx
+++ b/components/preview/preview-body.tsx
@@ -36,9 +36,10 @@ export default function PreviewBody() {
     <Box
       maxWidth={{ md: isPreview ? "100vw" : "" }}
       marginInline={{ md: isPreview ? "auto" : "" }}
-      p="4"
+      p="6"
     >
       <Stack 
+      pb="12"
 
       >
         <ReactMarkdown className="preview-markdown">

--- a/components/preview/preview-body.tsx
+++ b/components/preview/preview-body.tsx
@@ -37,9 +37,10 @@ export default function PreviewBody() {
       overflowY={"auto"}
       maxWidth={{ md: isPreview ? "100vw" : "" }}
       marginInline={{ md: isPreview ? "auto" : "" }}
+      p="4"
     >
       <Stack>
-        <ReactMarkdown>
+        <ReactMarkdown className="preview-markdown">
           {activeNote?.content ? activeNote.content : ""}
         </ReactMarkdown>
       </Stack>

--- a/components/preview/preview-body.tsx
+++ b/components/preview/preview-body.tsx
@@ -38,7 +38,7 @@ export default function PreviewBody() {
       marginInline={{ md: isPreview ? "auto" : "" }}
       p="6"
     >
-      <Stack 
+      <Stack
       pb="12"
 
       >

--- a/components/preview/preview-body.tsx
+++ b/components/preview/preview-body.tsx
@@ -34,12 +34,13 @@ export default function PreviewBody() {
 
   return (
     <Box
-      overflowY={"auto"}
       maxWidth={{ md: isPreview ? "100vw" : "" }}
       marginInline={{ md: isPreview ? "auto" : "" }}
       p="4"
     >
-      <Stack>
+      <Stack 
+
+      >
         <ReactMarkdown className="preview-markdown">
           {activeNote?.content ? activeNote.content : ""}
         </ReactMarkdown>

--- a/components/preview/preview-header.tsx
+++ b/components/preview/preview-header.tsx
@@ -12,15 +12,19 @@ export default function PreviewHeader() {
 
   return (
     <Box
-      minHeight={{ base: "10", md: "10" }}
+      // minHeight={{ base: "10", md: "10" }}
       _dark={{ bg: "whiteAlpha.100" }}
       bg="blackAlpha.100"
+      px="4"
+      py="3"
     >
       <Flex align="center" justify="space-between">
-        <Box textTransform="uppercase">preview</Box>
+        <Box fontSize="sm" letterSpacing="widest" opacity="0.75" textTransform="uppercase">preview</Box>
         <IconButton
           icon={<ViewIcon />}
           onClick={handleOnClick}
+          size="sm"
+          variant="link"
           aria-label="Toggle markdown preview"
         />
       </Flex>

--- a/components/preview/preview.tsx
+++ b/components/preview/preview.tsx
@@ -7,13 +7,16 @@ import PreviewBody from "@/components/preview/preview-body";
 
 export default function Preview() {
   return (
-    <Box className="preview"
-    h={"calc(100vh - 80px)"} 
-    minH={"calc(100vh - 123px)"}
-    overflowY="scroll"
-    >
+    <Box className="preview" scrollMargin="4">
       <PreviewHeader />
-      <PreviewBody />
+      <Box
+        overflowY={"scroll"}
+        // scrollMarginTop="4"
+        h={"calc(100vh - 80px)"}
+        minH={"calc(100vh - 123px)"}
+      >
+        <PreviewBody />
+      </Box>
     </Box>
   );
 }

--- a/components/preview/preview.tsx
+++ b/components/preview/preview.tsx
@@ -7,7 +7,11 @@ import PreviewBody from "@/components/preview/preview-body";
 
 export default function Preview() {
   return (
-    <Box className="preview" h={"calc(100vh - 80px)"} minH={"calc(100vh - 123px)"}>
+    <Box className="preview"
+    h={"calc(100vh - 80px)"} 
+    minH={"calc(100vh - 123px)"}
+    overflowY="scroll"
+    >
       <PreviewHeader />
       <PreviewBody />
     </Box>

--- a/components/sidebar/sidebar-logo.tsx
+++ b/components/sidebar/sidebar-logo.tsx
@@ -11,7 +11,7 @@ export default function Logo() {
       borderInlineEndColor="blackAlpha.400"
       h="full"
     >
-      <Text fontSize={{ base: "sm", md: "sm" }} lineHeight="base" fontWeight="bold" letterSpacing="0.5ch" textTransform="uppercase">markdown</Text>
+      <Text my="0" py="0" fontSize={{ base: "sm", md: "sm" }} lineHeight="base" fontWeight="bold" letterSpacing="0.5ch" textTransform="uppercase">markdown</Text>
     </Box>
   )
 }

--- a/components/sidebar/sidebar-logo.tsx
+++ b/components/sidebar/sidebar-logo.tsx
@@ -15,4 +15,3 @@ export default function Logo() {
     </Box>
   )
 }
-

--- a/components/sidebar/sidebar-new-note-button.tsx
+++ b/components/sidebar/sidebar-new-note-button.tsx
@@ -1,15 +1,14 @@
-import { Button } from '@chakra-ui/react'
 import { ActionType, AppContext } from "@/store/AppContext";
-import React, { useContext, useState } from "react";
-import { PlusSquareIcon } from '@chakra-ui/icons';
-import { nanoid } from 'nanoid';
-import { getTimestamp } from '@/utils/get-timestamp';
-import { INote } from '@/types/inote';
-
+import React, { useContext } from "react";
+import { PlusSquareIcon } from "@chakra-ui/icons";
+import { nanoid } from "nanoid";
+import { getTimestamp } from "@/utils/get-timestamp";
+import { INote } from "@/types/inote";
+import { ButtonOrange } from "../common/button-orange";
 
 export default function SidebarNewNoteButton() {
   const { state, dispatch } = useContext(AppContext);
-  const { activeNote, notes } = state;
+  // const { activeNote, notes } = state;
 
   const addNewNote = () => {
     const newNote: INote = {
@@ -23,10 +22,14 @@ export default function SidebarNewNoteButton() {
   };
 
   return (
-    <Button w="full" leftIcon={<PlusSquareIcon />} onClick={addNewNote}>
+    <ButtonOrange
+      props={{
+        w: "full",
+        leftIcon: <PlusSquareIcon />,
+        onClick: addNewNote,
+      }}
+    >
       Create new
-    </Button>
-
-  )
+    </ButtonOrange>
+  );
 }
-

--- a/components/sidebar/sidebar-note.tsx
+++ b/components/sidebar/sidebar-note.tsx
@@ -50,4 +50,3 @@ export default function SidebarNote({ nanoid, createdAt, title, id }: SidebarNot
     </ListItem>
   )
 }
-

--- a/components/sidebar/sidebar-note.tsx
+++ b/components/sidebar/sidebar-note.tsx
@@ -1,5 +1,6 @@
 import { ActionType, AppContext } from '@/store/AppContext';
-import { Text, ListItem, Button, Show, Grid, Stack, Tooltip, IconButton, useToast, Flex, Box, HStack } from '@chakra-ui/react'
+import { convertTimestamp } from '@/utils/convert-timestamp-human';
+import { Text, ListItem, Button, Show, Grid, Stack, Tooltip, IconButton, useToast, Flex, Box, HStack, Center } from '@chakra-ui/react'
 import React, { useContext } from 'react'
 import { DocumentIcon } from '../icons/icons';
 
@@ -20,36 +21,6 @@ export default function SidebarNote({ nanoid, createdAt, title, id }: SidebarNot
     }
   }
 
-  function handleOnClickCopyMarkdown() {
-    let contentToCopy = activeNote?.content.trim();
-    if (typeof contentToCopy !== "undefined" && contentToCopy.length > 0) {
-      try {
-        navigator.clipboard.writeText(contentToCopy);
-        toast({
-          title: "Copied markdown content",
-          status: "success",
-          duration: 3000,
-          isClosable: true,
-        });
-      } catch (err) {
-        toast({
-          title: "No content to copy",
-          description: JSON.stringify(err),
-          status: "error",
-          duration: 3000,
-          isClosable: true,
-        });
-      }
-    } else {
-      toast({
-        title: "No content to copy",
-        status: "error",
-        duration: 3000,
-        isClosable: true,
-      });
-    }
-  }
-
   return (
     <ListItem overflowX="hidden">
       <Button variant="ghost" w="full" rounded="none" h="full" title={title} onClick={handleOnClickSetActiveNote}>
@@ -58,23 +29,18 @@ export default function SidebarNote({ nanoid, createdAt, title, id }: SidebarNot
           pos="relative"
           overflowX="auto"
           w="full"
-          gap="2"
+          gap="0"
           alignItems="center"
+          px="1"
         >
-          <Tooltip
-          // label={ activeNote ? `copy contents of ${activeNote.title.trim()}.md` : "" }
-          >
-            <IconButton
-              variant="ghost"
-              size="sm"
-              stroke="gray.300"
-              icon={<DocumentIcon aria-hidden="true" />}
-              aria-label="copy markdown"
-              onClick={handleOnClickCopyMarkdown}
-            />
-          </Tooltip>
+          <Center stroke="gray.300"><DocumentIcon aria-hidden="true" /></Center>
           <Grid ml="4" textAlign="start" py="1">
-            <Show above="sm"><Box opacity="0.5" w="fit" fontSize="xs" lineHeight="none">{createdAt}</Box></Show>
+            <Show above="sm">
+              <Box opacity="0.5" w="fit" fontSize="xs" lineHeight="none">
+                {convertTimestamp(createdAt)}
+              </Box>
+
+            </Show>
             <Box w="min" color={activeNote?.nanoid === nanoid ? "orange.400" : ""}>
               {title}
             </Box>

--- a/components/sidebar/sidebar-theme-toggle.tsx
+++ b/components/sidebar/sidebar-theme-toggle.tsx
@@ -8,6 +8,8 @@ export function SidebarThemeToggle() {
       aria-label="toggle theme"
       rounded="full"
       size="xs"
+      marginInline="auto"
+      w="1"
       onClick={toggleColorMode}
       icon={colorMode === "dark" ? <SunIcon /> : <MoonIcon />}
     />

--- a/components/sidebar/sidebar-theme-toggle.tsx
+++ b/components/sidebar/sidebar-theme-toggle.tsx
@@ -1,0 +1,16 @@
+import { MoonIcon, SunIcon } from "@chakra-ui/icons";
+import { IconButton, useColorMode } from "@chakra-ui/react";
+
+export function SidebarThemeToggle() {
+  const { toggleColorMode, colorMode } = useColorMode();
+  return (
+    <IconButton
+      aria-label="toggle theme"
+      rounded="full"
+      size="xs"
+      onClick={toggleColorMode}
+      icon={colorMode === "dark" ? <SunIcon /> : <MoonIcon />}
+    />
+  );
+}
+

--- a/components/sidebar/sidebar-theme-toggle.tsx
+++ b/components/sidebar/sidebar-theme-toggle.tsx
@@ -15,4 +15,3 @@ export function SidebarThemeToggle() {
     />
   );
 }
-

--- a/components/sidebar/sidebar.tsx
+++ b/components/sidebar/sidebar.tsx
@@ -1,8 +1,11 @@
-import { Box, Text, chakra, Stack, Grid } from "@chakra-ui/react";
 import React from "react";
+
+import { Box, Text, chakra, Stack, Grid } from "@chakra-ui/react";
+
 import SidebarNotes from "@/components/sidebar/sidebar-notes";
 import Logo from "@/components/sidebar/sidebar-logo";
 import SidebarNewNoteButton from "@/components/sidebar/sidebar-new-note-button";
+import { SidebarThemeToggle } from "@/components/sidebar/sidebar-theme-toggle";
 
 export default function Sidebar() {
   return (
@@ -37,7 +40,7 @@ export default function Sidebar() {
             </Box>
             <SidebarNotes />
           </Stack>
-          {/* <ThemeToggle/> */}
+          <SidebarThemeToggle/> 
         </Grid>
       </>
     </chakra.aside>

--- a/components/sidebar/sidebar.tsx
+++ b/components/sidebar/sidebar.tsx
@@ -14,18 +14,17 @@ export default function Sidebar() {
       className="sidebar"
       h="100vh"
       pos="relative"
-      // px="6"
-      py={{ base: 7, md: 7 }}
+      py={{ base: 6, md: 7 }}
       bg="blackAlpha.50"
       _dark={{ bg: "whiteAlpha.50" }}
     >
-        <Flex justify="space-between" px="6">
+        <Flex justify="space-between" align="center" px="6">
           <Logo />
           <SidebarThemeToggle/> 
         </Flex>
 
         <Grid gap="6">
-          <Stack spacing="6" my="6">
+          <Stack spacing="6" my={{base:6,md:6}}>
             <Text
               textTransform="uppercase"
               fontSize="xs"
@@ -34,6 +33,7 @@ export default function Sidebar() {
               fontWeight="medium"
               my="0"
               px="6"
+              py={{md:"3"}}
             >
               my notes
             </Text>

--- a/components/sidebar/sidebar.tsx
+++ b/components/sidebar/sidebar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Box, Text, chakra, Stack, Grid } from "@chakra-ui/react";
+import { Box, Text, chakra, Stack, Grid, Flex } from "@chakra-ui/react";
 
 import SidebarNotes from "@/components/sidebar/sidebar-notes";
 import Logo from "@/components/sidebar/sidebar-logo";
@@ -15,14 +15,15 @@ export default function Sidebar() {
       h="100vh"
       pos="relative"
       // px="6"
-      py={{ base: 6, md: 6 }}
+      py={{ base: 7, md: 7 }}
       bg="blackAlpha.50"
       _dark={{ bg: "whiteAlpha.50" }}
     >
-      <>
-        <Box px="6">
+        <Flex justify="space-between" px="6">
           <Logo />
-        </Box>
+          <SidebarThemeToggle/> 
+        </Flex>
+
         <Grid gap="6">
           <Stack spacing="6" my="6">
             <Text
@@ -31,6 +32,7 @@ export default function Sidebar() {
               letterSpacing="widest"
               opacity="0.7"
               fontWeight="medium"
+              my="0"
               px="6"
             >
               my notes
@@ -40,9 +42,7 @@ export default function Sidebar() {
             </Box>
             <SidebarNotes />
           </Stack>
-          <SidebarThemeToggle/> 
         </Grid>
-      </>
     </chakra.aside>
   );
 }

--- a/components/sidebar/sidebar.tsx
+++ b/components/sidebar/sidebar.tsx
@@ -1,8 +1,8 @@
-import { Box, Text, chakra, Stack, Grid } from '@chakra-ui/react'
-import React from 'react'
-import SidebarNotes from '@/components/sidebar/sidebar-notes'
-import Logo from '@/components/sidebar/sidebar-logo'
-import SidebarNewNoteButton from '@/components/sidebar/sidebar-new-note-button'
+import { Box, Text, chakra, Stack, Grid } from "@chakra-ui/react";
+import React from "react";
+import SidebarNotes from "@/components/sidebar/sidebar-notes";
+import Logo from "@/components/sidebar/sidebar-logo";
+import SidebarNewNoteButton from "@/components/sidebar/sidebar-new-note-button";
 
 export default function Sidebar() {
   return (
@@ -11,25 +11,35 @@ export default function Sidebar() {
       className="sidebar"
       h="100vh"
       pos="relative"
-      // px="6" 
+      // px="6"
       py={{ base: 6, md: 6 }}
-      bg="blackAlpha.50" _dark={{ bg: "whiteAlpha.50" }}
+      bg="blackAlpha.50"
+      _dark={{ bg: "whiteAlpha.50" }}
     >
       <>
-        <Box px="6"><Logo /></Box>
+        <Box px="6">
+          <Logo />
+        </Box>
         <Grid gap="6">
           <Stack spacing="6" my="6">
-            <Text textTransform="uppercase" fontSize="xs" letterSpacing="widest" opacity="0.7" fontWeight="medium" px="6">
+            <Text
+              textTransform="uppercase"
+              fontSize="xs"
+              letterSpacing="widest"
+              opacity="0.7"
+              fontWeight="medium"
+              px="6"
+            >
               my notes
             </Text>
-            <Box px="6"><SidebarNewNoteButton /></Box>
+            <Box px="6">
+              <SidebarNewNoteButton />
+            </Box>
             <SidebarNotes />
           </Stack>
           {/* <ThemeToggle/> */}
         </Grid>
       </>
     </chakra.aside>
-  )
+  );
 }
-
-

--- a/components/sidebar/sidebar.tsx
+++ b/components/sidebar/sidebar.tsx
@@ -20,7 +20,7 @@ export default function Sidebar() {
     >
         <Flex justify="space-between" align="center" px="6">
           <Logo />
-          <SidebarThemeToggle/> 
+          <SidebarThemeToggle/>
         </Flex>
 
         <Grid gap="6">

--- a/hooks/use-local-storage.tsx
+++ b/hooks/use-local-storage.tsx
@@ -42,4 +42,3 @@ export function useLocalStorage({ dispatch, toast }: UseLocalStorageProps) {
 
   }, []);
 }
-

--- a/hooks/use-local-storage.tsx
+++ b/hooks/use-local-storage.tsx
@@ -30,15 +30,13 @@ export function useLocalStorage({ dispatch, toast }: UseLocalStorageProps) {
     // If notes exist in local storage, dispatch them to the store and show user message
     if (localStorageData !== null) {
       dispatch({ type: ActionType.FETCH_NOTES, payload: localStorageData });
-
-      toast({ title: "Local storage notes found", status: "info", duration: 3000, isClosable: true, });
       dispatch({ type: ActionType.SET_ACTIVE_NOTE, payload: localStorageData[0] });
+      toast({ title: "Local storage notes found", status: "info", duration: 3000, isClosable: true, });
     } else {
       // If notes don't exist in local storage, dispatch sample data to store and save it to local storage, show user message
       dispatch({ type: ActionType.FETCH_NOTES, payload: data });
-      localStoreSaveItem(KEY_LOCAL_STORAGE_NOTES, data);
       dispatch({ type: ActionType.SET_ACTIVE_NOTE, payload: data[0] });
-
+      localStoreSaveItem(KEY_LOCAL_STORAGE_NOTES, data);
       toast({ title: "Loading sample data", status: "info", duration: 3000, isClosable: true, });
     }
 

--- a/hooks/use-local-storage.tsx
+++ b/hooks/use-local-storage.tsx
@@ -32,10 +32,12 @@ export function useLocalStorage({ dispatch, toast }: UseLocalStorageProps) {
       dispatch({ type: ActionType.FETCH_NOTES, payload: localStorageData });
 
       toast({ title: "Local storage notes found", status: "info", duration: 3000, isClosable: true, });
+      dispatch({ type: ActionType.SET_ACTIVE_NOTE, payload: localStorageData[0] });
     } else {
       // If notes don't exist in local storage, dispatch sample data to store and save it to local storage, show user message
       dispatch({ type: ActionType.FETCH_NOTES, payload: data });
       localStoreSaveItem(KEY_LOCAL_STORAGE_NOTES, data);
+      dispatch({ type: ActionType.SET_ACTIVE_NOTE, payload: data[0] });
 
       toast({ title: "Loading sample data", status: "info", duration: 3000, isClosable: true, });
     }

--- a/lib/theme.tsx
+++ b/lib/theme.tsx
@@ -1,6 +1,8 @@
 import { extendTheme, ThemeConfig } from "@chakra-ui/react";
 import { mode } from "@chakra-ui/theme-tools";
 
+// Mental model: If you need a spacing of 40px, divide it by 4. That'll give you 10. Then use it in your component.
+
 const config: ThemeConfig = {
   initialColorMode: "dark",
   useSystemColorMode: true,
@@ -151,8 +153,43 @@ const colors = {
   },
 };
 
+const fontSizes = {
+  xs: "0.75rem",
+  sm: "0.875rem",
+  md: "1rem",
+  lg: "1.125rem",
+  xl: "1.25rem",
+  "2xl": "1.5rem",
+  "3xl": "1.875rem",
+  "4xl": "2.25rem",
+  "5xl": "3rem",
+  "6xl": "3.75rem",
+  "7xl": "4.5rem",
+  "8xl": "6rem",
+  "9xl": "8rem",
+};
+
+const lineHeights = {
+  normal: "normal",
+  none: 1,
+  shorter: 1.25,
+  short: 1.375,
+  base: 1.5,
+  tall: 1.625,
+  taller: "2",
+  "3": ".75rem",
+  "4": "1rem",
+  "5": "1.25rem",
+  "6": "1.5rem",
+  "7": "1.75rem",
+  "8": "2rem",
+  "9": "2.25rem",
+  "10": "2.5rem",
+};
+
 export const theme = extendTheme({
   space,
+  fontSizes,
   shadows,
   colors,
   config,

--- a/lib/theme.tsx
+++ b/lib/theme.tsx
@@ -45,6 +45,10 @@ const styles = {
         },
       },
     },
+    "ul,ol": {
+      listStyle: "none",
+      // paddingInlineStart: "8px",
+    },
     ".img": {
       rounded: "lg",
     },
@@ -60,7 +64,6 @@ const styles = {
         opacity: 1,
       },
     },
-
     h1: { fontSize: "3xl", lineHeight: "base", fontWeight: "bold" },
     h2: { fontSize: "2xl", lineHeight: "base", fontWeight: "bold" },
     h3: { fontSize: "xl", lineHeight: "base", fontWeight: "bold" },

--- a/lib/theme.tsx
+++ b/lib/theme.tsx
@@ -17,6 +17,12 @@ const styles = {
       fontFamily: "body",
       lineHeight: "base",
     },
+    ".preview-markdown :where(h1,h2,h3,h4,h5,h6)": {
+      fontFamily: "var(--chakra-fonts-heading)",
+    },
+    ".markdown-editor textarea":{
+      fontFamily: "var(--chakra-fonts-code)",
+    },
     "*::placeholder": {
       color: mode("gray.400", "whiteAlpha.400")(props),
     },
@@ -24,7 +30,6 @@ const styles = {
       borderColor: mode("gray.200", "whiteAlpha.300")(props),
       wordWrap: "break-word",
     },
-
     "html, body": {
       bg: props.colorMode === "dark" ? "gray.900" : "gray.50",
       color: props.colorMode === "dark" ? "gray.50" : "gray.600",

--- a/lib/theme.tsx
+++ b/lib/theme.tsx
@@ -4,7 +4,7 @@ import { mode } from "@chakra-ui/theme-tools";
 // Mental model: If you need a spacing of 40px, divide it by 4. That'll give you 10. Then use it in your component.
 
 const config: ThemeConfig = {
-  initialColorMode: "dark",
+  initialColorMode: "system", // "dark" | "light" | "system".
   useSystemColorMode: true,
 };
 
@@ -12,8 +12,8 @@ const config: ThemeConfig = {
 const styles = {
   global: (props: Record<string, any>) => ({
     body: {
-      color: mode("gray.800", "whiteAlpha.900")(props),
-      bg: mode("white", "gray.800")(props),
+      bg: mode("gray.50", "gray.900")(props),
+      color: mode( "gray.600", "gray.50",)(props),
       fontFamily: "body",
       lineHeight: "base",
     },
@@ -24,15 +24,15 @@ const styles = {
       fontFamily: "var(--chakra-fonts-code)",
     },
     "*::placeholder": {
-      color: mode("gray.400", "whiteAlpha.400")(props),
+      color: mode("gray.400", "gray.200")(props),
     },
     "*, *::before, &::after": {
       borderColor: mode("gray.200", "whiteAlpha.300")(props),
       wordWrap: "break-word",
     },
     "html, body": {
-      bg: props.colorMode === "dark" ? "gray.900" : "gray.50",
-      color: props.colorMode === "dark" ? "gray.50" : "gray.600",
+      // bg: props.colorMode === "dark" ? "gray.900" : "gray.50",
+      // color: props.colorMode === "dark" ? "gray.50" : "gray.600",
       minH: "100vh",
       overflowX: "hidden",
       colorScheme: "dark",

--- a/lib/theme.tsx
+++ b/lib/theme.tsx
@@ -17,10 +17,10 @@ const styles = {
       fontFamily: "body",
       lineHeight: "base",
     },
-    ".preview-markdown :where(h1,h2,h3,h4,h5,h6)": {
-      fontFamily: "var(--chakra-fonts-heading)",
-    },
-    ".markdown-editor textarea":{
+    // ".preview-markdown :where(h1,h2,h3,h4,h5,h6)": {
+    //   fontFamily: "var(--chakra-fonts-heading)",
+    // },
+    ".markdown-editor textarea": {
       fontFamily: "var(--chakra-fonts-code)",
     },
     "*::placeholder": {
@@ -69,11 +69,42 @@ const styles = {
         opacity: 1,
       },
     },
-    h1: { fontSize: "3xl", lineHeight: "base", fontWeight: "bold" },
-    h2: { fontSize: "2xl", lineHeight: "base", fontWeight: "bold" },
-    h3: { fontSize: "xl", lineHeight: "base", fontWeight: "bold" },
-    h4: { fontSize: "md", lineHeight: "base", fontWeight: "bold" },
-    h5: { fontSize: "sm", lineHeight: "base", fontWeight: "bold" },
+    h1: {
+      fontSize: "3xl",
+      lineHeight: "base",
+      fontWeight: "bold",
+      marginBottom: "1rem",
+    },
+    h2: {
+      fontSize: "2xl",
+      lineHeight: "base",
+      fontWeight: "thin",
+      marginBottom: "1rem",
+    },
+    h3: {
+      fontSize: "xl",
+      lineHeight: "base",
+      fontWeight: "bold",
+      marginBottom: "1rem",
+    },
+    h4: {
+      fontSize: "md",
+      lineHeight: "base",
+      fontWeight: "bold",
+      marginBottom: "1rem",
+    },
+    h5: {
+      fontSize: "sm",
+      lineHeight: "base",
+      fontWeight: "bold",
+      marginBottom: "1rem",
+    },
+    h6: {
+      fontSize: "xs",
+      lineHeight: "base",
+      fontWeight: "bold",
+      marginBottom: "1rem",
+    },
     "p, ul, ol": { mb: "4" },
   }),
 };
@@ -137,7 +168,7 @@ const colors = {
   gray: {
     50: "#F1F2F3",
     100: "#D8DADE",
-    200: "#BFC2C9",
+    200: "#C1C4CB",
     300: "#A6AAB4",
     400: "#7D8188",
     500: "#747A8B",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,16 @@ import { AppContextProvider } from "@/store/AppContext";
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
-      <ChakraProvider theme={updateTheme}>
+      <ChakraProvider
+        theme={updateTheme}
+        toastOptions={{
+          defaultOptions: {
+            position: 'bottom', 
+            duration: 3000,
+            isClosable: true,
+          }
+        }}
+      >
         <AppContextProvider>
           <Component {...pageProps} />
         </AppContextProvider>
@@ -20,10 +29,8 @@ export default function App({ Component, pageProps }: AppProps) {
   );
 }
 
-//
-// Google fonts with next need to be loaded in a tsx file here.
-// .
 
+// Google fonts with NextJS need to be loaded in a tsx file here.
 const roboto = Roboto({ weight: ["300", "400"], subsets: ["latin"] });
 const robotoMono = Roboto_Mono({ subsets: ["latin"] });
 const robotoSlab = Roboto_Slab({

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,10 +15,10 @@ export default function App({ Component, pageProps }: AppProps) {
         theme={updateTheme}
         toastOptions={{
           defaultOptions: {
-            position: 'bottom', 
+            position: "bottom",
             duration: 3000,
             isClosable: true,
-          }
+          },
         }}
       >
         <AppContextProvider>
@@ -28,7 +28,6 @@ export default function App({ Component, pageProps }: AppProps) {
     </>
   );
 }
-
 
 // Google fonts with NextJS need to be loaded in a tsx file here.
 const roboto = Roboto({ weight: ["300", "400"], subsets: ["latin"] });
@@ -43,4 +42,11 @@ const fonts = {
   body: roboto.style.fontFamily,
   code: robotoMono.style.fontFamily,
 };
-const updateTheme = extendTheme({ ...theme, fonts: fonts });
+const updateTheme = extendTheme({
+  ...theme,
+  fonts: fonts,
+
+  // global: (props: Record<string, any>) => ({
+  //   ...global,
+  // }),
+});

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -33,7 +33,7 @@ export default function App({ Component, pageProps }: AppProps) {
 const roboto = Roboto({ weight: ["300", "400"], subsets: ["latin"] });
 const robotoMono = Roboto_Mono({ subsets: ["latin"] });
 const robotoSlab = Roboto_Slab({
-  weight: ["300", "500", "700"],
+  weight: ["200", "400", "500", "700"],
   subsets: ["latin"],
 });
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,13 +1,17 @@
-import { Html, Head, Main, NextScript } from 'next/document'
+import { Html, Head, Main, NextScript } from "next/document";
+import { ColorModeScript } from "@chakra-ui/react";
+import { theme } from "@/lib/theme";
 
 export default function Document() {
   return (
     <Html lang="en">
       <Head />
       <body className="menu-closed">
+        {/* https://chakra-ui.com/docs/styled-system/color-mode#color-mode-flash-issue */}
+        <ColorModeScript initialColorMode={theme.config.initialColorMode} />
         <Main />
         <NextScript />
       </body>
     </Html>
-  )
+  );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,14 +20,11 @@ export default function Home() {
   useLocalStorage({ dispatch: dispatch, toast: toast });
 
   return (
-    <Grid
-    // gap="px"
-      className={`wrapper ${isPreview ? "preview-open" : "preview-closed"}`}
-    >
+    <Grid className={`wrapper ${isPreview ? "preview-open" : "preview-closed"}`} >
       <Sidebar />
       <Box>
         <Navbar />
-        <chakra.main>
+        <chakra.main borderInlineStart={"thin solid"} borderInlineStartColor="blackAlpha.100" _dark={{borderInlineStartColor:"whiteAlpha.100"}}>
           <Editor />
         </chakra.main>
       </Box>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,7 +11,6 @@ import {
 import { useContext, } from "react";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 
-
 export default function Home() {
   const toast = useToast();
   const { state, dispatch } = useContext(AppContext);
@@ -22,9 +21,10 @@ export default function Home() {
   return (
     <Grid className={`wrapper ${isPreview ? "preview-open" : "preview-closed"}`} >
       <Sidebar />
+
       <Box>
         <Navbar />
-        <chakra.main borderInlineStart={"thin solid"} borderInlineStartColor="blackAlpha.100" _dark={{borderInlineStartColor:"whiteAlpha.100"}}>
+        <chakra.main borderInlineStart={"thin solid"} borderInlineStartColor="blackAlpha.100" _dark={{ borderInlineStartColor: "whiteAlpha.100" }}>
           <Editor />
         </chakra.main>
       </Box>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,10 +13,10 @@ import { useLocalStorage } from "@/hooks/use-local-storage";
 
 
 export default function Home() {
+  const toast = useToast();
   const { state, dispatch } = useContext(AppContext);
   const { isPreview } = state;
 
-  const toast = useToast();
   useLocalStorage({ dispatch: dispatch, toast: toast });
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,10 +12,10 @@ import { useContext, } from "react";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 
 export default function Home() {
-  const toast = useToast();
   const { state, dispatch } = useContext(AppContext);
   const { isPreview } = state;
 
+  const toast = useToast();
   useLocalStorage({ dispatch: dispatch, toast: toast });
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,6 +21,7 @@ export default function Home() {
 
   return (
     <Grid
+    // gap="px"
       className={`wrapper ${isPreview ? "preview-open" : "preview-closed"}`}
     >
       <Sidebar />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,7 +1,7 @@
 body {
-  overflow:hidden;
-  position:fixed;
-  height:100vh;
+  overflow: hidden;
+  position: fixed;
+  height: 100vh;
 }
 
 .wrapper {
@@ -38,3 +38,30 @@ body {
   height: calc(100vh - 80px);
 }
 
+.preview-markdown :is(ol, ul, menu) {
+  margin-inline-start: 1rem;
+}
+
+.preview-markdown ul li {
+  list-style-type: disc;
+}
+
+.preview-markdown ol li {
+  list-style-type: decimal;
+}
+
+/* TODO: Move all to style with chakra-ui in @/lib/theme.ts */
+.preview-markdown blockquote {
+  padding: 1rem;
+  border-inline-start: 4px solid orange;
+  margin-bottom: 1rem;
+}
+
+.preview-markdown blockquote > *:last-child {
+  margin-block: 0;
+}
+.preview-markdown ul li::marker,
+.preview-markdown ol li::marker,
+.preview-markdown menu li::marker {
+  color: rgb(228 102 67);
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -50,6 +50,25 @@ body {
   list-style-type: decimal;
 }
 
+.preview-markdown pre {
+  background-color: var(--chakra-colors-gray-700);
+  border-radius: 5px;
+  padding: 1rem;
+}
+
+.preview-markdown code {
+  font-size: var(--chakra-fontSizes-xs);
+  font-family: var(--chakra-fonts-code);
+}
+
+.preview-markdown :not(pre) > code {
+  background-color: var(--chakra-colors-gray-700);
+  font-family: var(--chakra-fonts-code);
+  padding-inline: 0.5ch;
+  margin-inline: 0.2ch;
+  border-radius: 3px;
+}
+
 /* https://chakra-ui.com/docs/styled-system/css-variables */
 /* TODO: Move all to style with chakra-ui in @/lib/theme.ts */
 .preview-markdown blockquote {
@@ -57,7 +76,14 @@ body {
   border-inline-start: 4px solid var(--chakra-colors-orange-400);
   background-color: var(--chakra-colors-gray-100);
   margin-bottom: 1rem;
+  border-radius: 2px;
 }
+
+.preview-markdown blockquote > :is(p, span) {
+  font-size: var(--chakra-fontSizes-sm);
+  font-weight: bold;
+}
+
 [data-theme="dark"] .preview-markdown blockquote {
   background-color: var(--chakra-colors-gray-800);
 }
@@ -65,14 +91,29 @@ body {
 .preview-markdown blockquote > *:last-child {
   margin-block: 0;
 }
-.preview-markdown ul li::marker,
-.preview-markdown ol li::marker,
-.preview-markdown menu li::marker {
-  color: rgb(228 102 67);
-}
 
 .preview-markdown :where(h1, h2, h3, h4, h5, h6) {
+  font-family: var(--chakra-fonts-heading);
   position: relative;
+  letter-spacing: var(--chakra-letterSpacings-wide);
+}
+
+.preview-markdown :where(p, li) {
+  font-weight: var(--chakra-fontWeights-medium);
+  font-size: var(--chakra-fontSizes-sm);
+  color: var(--chakra-colors-gray-200);
+  font-family: var(--chakra-fonts-heading);
+}
+
+.preview-markdown ol li::marker,
+.preview-markdown menu li::marker {
+  color: var(--chakra-colors-gray-400);
+  font-size: var(--chakra-fontSizes-sm);
+  font-weight: bold;
+}
+
+.preview-markdown ul li::marker {
+  color: rgb(228 102 67);
 }
 
 .preview-markdown :is(h1, h2, h3, h4, h5, h6)::before {
@@ -80,11 +121,9 @@ body {
   font-size: 75%;
   bottom: 1/2;
   right: 0;
-  opacity: 0.1;
-  transition-property: opacity;
+  opacity: 0.2;
   transition-delay: 300ms;
-  transition-duration: 300ms;
-  transition-timing-function: ease-out;
+  transition: opacity 300ms ease-out;
 }
 
 [data-theme="dark"] .preview-markdown :is(h1, h2, h3, h4, h5, h6)::before {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -50,11 +50,16 @@ body {
   list-style-type: decimal;
 }
 
+/* https://chakra-ui.com/docs/styled-system/css-variables */
 /* TODO: Move all to style with chakra-ui in @/lib/theme.ts */
 .preview-markdown blockquote {
   padding: 1rem;
-  border-inline-start: 4px solid orange;
+  border-inline-start: 4px solid var(--chakra-colors-orange-400);
+  background-color: var(--chakra-colors-gray-100);
   margin-bottom: 1rem;
+}
+[data-theme="dark"] .preview-markdown blockquote {
+  background-color: var(--chakra-colors-gray-800);
 }
 
 .preview-markdown blockquote > *:last-child {
@@ -64,4 +69,48 @@ body {
 .preview-markdown ol li::marker,
 .preview-markdown menu li::marker {
   color: rgb(228 102 67);
+}
+
+.preview-markdown :where(h1, h2, h3, h4, h5, h6) {
+  position: relative;
+}
+
+.preview-markdown :is(h1, h2, h3, h4, h5, h6)::before {
+  position: absolute;
+  font-size: 75%;
+  bottom: 1/2;
+  right: 0;
+  opacity: 0.1;
+  transition-property: opacity;
+  transition-delay: 300ms;
+  transition-duration: 300ms;
+  transition-timing-function: ease-out;
+}
+
+[data-theme="dark"] .preview-markdown :is(h1, h2, h3, h4, h5, h6)::before {
+  opacity: 0.05;
+}
+
+.preview-markdown :is(h1, h2, h3, h4, h5, h6):hover::before {
+  transition-delay: 100ms;
+  opacity: 1;
+}
+
+.preview-markdown :is(h1)::before {
+  content: "#";
+}
+.preview-markdown :is(h2)::before {
+  content: "##";
+}
+.preview-markdown :is(h3)::before {
+  content: "###";
+}
+.preview-markdown :is(h4)::before {
+  content: "####";
+}
+.preview-markdown :is(h5)::before {
+  content: "#####";
+}
+.preview-markdown :is(h6)::before {
+  content: "######";
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -83,7 +83,7 @@ body {
 
 /* Increase the opacity of the pseudo-element for headings on hover */
 [data-theme="dark"] .preview-markdown :is(h1, h2, h3, h4, h5, h6)::before {
-  opacity: 0.05;
+  opacity: 0.1;
 }
 
 /* Increase the opacity of the pseudo-element for headings on hover */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -49,8 +49,12 @@ body {
 .preview-markdown :where(p, li) {
   font-weight: var(--chakra-fontWeights-medium);
   font-size: var(--chakra-fontSizes-sm);
-  color: var(--chakra-colors-gray-200);
   font-family: var(--chakra-fonts-heading);
+}
+
+/* Increase to classic gray color for reading preview content */
+[data-theme="dark"] .preview-markdown :where(p, li) {
+  color: var(--chakra-colors-gray-200);
 }
 
 /* Apply marker style to unordered list items */
@@ -125,12 +129,16 @@ body {
 
 /* Styles for <pre> element */
 .preview-markdown pre {
-  background-color: var(--chakra-colors-gray-700);
+  background-color: var(--chakra-colors-blackAlpha-100);
   border-radius: 5px;
   padding: 1rem;
   overflow-x: scroll;
   scroll-behavior: smooth;
   scrollbar-width: thin;
+}
+
+[data-theme="dark"] .preview-markdown pre {
+  background-color: var(--chakra-colors-gray-700);
 }
 
 /* Styles for <code> element inside <pre> */
@@ -142,7 +150,7 @@ body {
 /* Styles for <code> element outside <pre> */
 .preview-markdown :not(pre) > code {
   font-size: var(--chakra-fontSizes-xs);
-  background-color: var(--chakra-colors-gray-700);
+  background-color: var(--chakra-colors-blackAlpha-200);
   font-family: var(--chakra-fonts-code);
   overflow-wrap: break-word;
   padding-inline: 0.5ch;
@@ -150,19 +158,25 @@ body {
   border-radius: 3px;
 }
 
+[data-theme="dark"] .preview-markdown :not(pre) > code  {
+  background-color: var(--chakra-colors-gray-700);
+}
+
 /* Styles for <blockquote> element */
 .preview-markdown blockquote {
-  padding: 1rem;
+  padding: clamp(0.618rem, 1vw, 1rem);
   border-inline-start: 4px solid var(--chakra-colors-orange-400);
-  background-color: var(--chakra-colors-gray-100);
+  background-color: var(--chakra-colors-blackAlpha-50);
   margin-bottom: 1rem;
   border-radius: 2px;
 }
 
 /* Styles for children of <blockquote> element */
 .preview-markdown blockquote > :is(p, span) {
-  font-size: var(--chakra-fontSizes-sm);
-  font-weight: bold;
+  font-weight: 100;
+  /* line-height: 1.4; */
+  /* font-size: var(--chakra-fontSizes-sm); */
+  color: var(--chakra-colors-gray-600);
 }
 
 /* Dark mode styles for <blockquote> element */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -54,6 +54,12 @@ body {
   background-color: var(--chakra-colors-gray-700);
   border-radius: 5px;
   padding: 1rem;
+  overflow-x: scroll;
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
+  /* text-overflow: ellipsis; */
+  /* white-space: pre-wrap; */
+  /* word-wrap: break-word; */
 }
 
 .preview-markdown code {
@@ -62,8 +68,10 @@ body {
 }
 
 .preview-markdown :not(pre) > code {
+  font-size: var(--chakra-fontSizes-xs);
   background-color: var(--chakra-colors-gray-700);
   font-family: var(--chakra-fonts-code);
+  overflow-wrap: break-word;
   padding-inline: 0.5ch;
   margin-inline: 0.2ch;
   border-radius: 3px;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -38,74 +38,14 @@ body {
   height: calc(100vh - 80px);
 }
 
-.preview-markdown :is(ol, ul, menu) {
-  margin-inline-start: 1rem;
-}
-
-.preview-markdown ul li {
-  list-style-type: disc;
-}
-
-.preview-markdown ol li {
-  list-style-type: decimal;
-}
-
-.preview-markdown pre {
-  background-color: var(--chakra-colors-gray-700);
-  border-radius: 5px;
-  padding: 1rem;
-  overflow-x: scroll;
-  scroll-behavior: smooth;
-  scrollbar-width: thin;
-  /* text-overflow: ellipsis; */
-  /* white-space: pre-wrap; */
-  /* word-wrap: break-word; */
-}
-
-.preview-markdown code {
-  font-size: var(--chakra-fontSizes-xs);
-  font-family: var(--chakra-fonts-code);
-}
-
-.preview-markdown :not(pre) > code {
-  font-size: var(--chakra-fontSizes-xs);
-  background-color: var(--chakra-colors-gray-700);
-  font-family: var(--chakra-fonts-code);
-  overflow-wrap: break-word;
-  padding-inline: 0.5ch;
-  margin-inline: 0.2ch;
-  border-radius: 3px;
-}
-
-/* https://chakra-ui.com/docs/styled-system/css-variables */
-/* TODO: Move all to style with chakra-ui in @/lib/theme.ts */
-.preview-markdown blockquote {
-  padding: 1rem;
-  border-inline-start: 4px solid var(--chakra-colors-orange-400);
-  background-color: var(--chakra-colors-gray-100);
-  margin-bottom: 1rem;
-  border-radius: 2px;
-}
-
-.preview-markdown blockquote > :is(p, span) {
-  font-size: var(--chakra-fontSizes-sm);
-  font-weight: bold;
-}
-
-[data-theme="dark"] .preview-markdown blockquote {
-  background-color: var(--chakra-colors-gray-800);
-}
-
-.preview-markdown blockquote > *:last-child {
-  margin-block: 0;
-}
-
+/* Apply font family, font size, font weight, and text color to paragraphs and list items */
 .preview-markdown :where(h1, h2, h3, h4, h5, h6) {
   font-family: var(--chakra-fonts-heading);
   position: relative;
   letter-spacing: var(--chakra-letterSpacings-wide);
 }
 
+/* Apply font family, font size, font weight, and text color to paragraphs and list items */
 .preview-markdown :where(p, li) {
   font-weight: var(--chakra-fontWeights-medium);
   font-size: var(--chakra-fontSizes-sm);
@@ -113,6 +53,7 @@ body {
   font-family: var(--chakra-fonts-heading);
 }
 
+/* Apply marker style to unordered list items */
 .preview-markdown ol li::marker,
 .preview-markdown menu li::marker {
   color: var(--chakra-colors-gray-400);
@@ -120,10 +61,12 @@ body {
   font-weight: bold;
 }
 
+/* Apply marker style to unordered list items */
 .preview-markdown ul li::marker {
-  color: rgb(228 102 67);
+  color: var(--chakra-colors-orange-400);
 }
 
+/* Increase the opacity of the pseudo-element for headings on hover */
 .preview-markdown :is(h1, h2, h3, h4, h5, h6)::before {
   position: absolute;
   font-size: 75%;
@@ -134,10 +77,12 @@ body {
   transition: opacity 300ms ease-out;
 }
 
+/* Increase the opacity of the pseudo-element for headings on hover */
 [data-theme="dark"] .preview-markdown :is(h1, h2, h3, h4, h5, h6)::before {
   opacity: 0.05;
 }
 
+/* Increase the opacity of the pseudo-element for headings on hover */
 .preview-markdown :is(h1, h2, h3, h4, h5, h6):hover::before {
   transition-delay: 100ms;
   opacity: 1;
@@ -160,4 +105,72 @@ body {
 }
 .preview-markdown :is(h6)::before {
   content: "######";
+}
+
+.preview-markdown :is(ol, ul, menu) {
+  margin-inline-start: 1rem;
+}
+
+.preview-markdown ul li {
+  list-style-type: disc;
+}
+
+.preview-markdown ol li {
+  list-style-type: decimal;
+}
+
+/* text-overflow: ellipsis; */
+/* white-space: pre-wrap; */
+/* word-wrap: break-word; */
+
+/* Styles for <pre> element */
+.preview-markdown pre {
+  background-color: var(--chakra-colors-gray-700);
+  border-radius: 5px;
+  padding: 1rem;
+  overflow-x: scroll;
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
+}
+
+/* Styles for <code> element inside <pre> */
+.preview-markdown pre code {
+  font-size: var(--chakra-fontSizes-xs);
+  font-family: var(--chakra-fonts-code);
+}
+
+/* Styles for <code> element outside <pre> */
+.preview-markdown :not(pre) > code {
+  font-size: var(--chakra-fontSizes-xs);
+  background-color: var(--chakra-colors-gray-700);
+  font-family: var(--chakra-fonts-code);
+  overflow-wrap: break-word;
+  padding-inline: 0.5ch;
+  margin-inline: 0.2ch;
+  border-radius: 3px;
+}
+
+/* Styles for <blockquote> element */
+.preview-markdown blockquote {
+  padding: 1rem;
+  border-inline-start: 4px solid var(--chakra-colors-orange-400);
+  background-color: var(--chakra-colors-gray-100);
+  margin-bottom: 1rem;
+  border-radius: 2px;
+}
+
+/* Styles for children of <blockquote> element */
+.preview-markdown blockquote > :is(p, span) {
+  font-size: var(--chakra-fontSizes-sm);
+  font-weight: bold;
+}
+
+/* Dark mode styles for <blockquote> element */
+[data-theme="dark"] .preview-markdown blockquote {
+  background-color: var(--chakra-colors-gray-800);
+}
+
+/* Styles for last child of <blockquote> element */
+.preview-markdown blockquote > *:last-child {
+  margin-block: 0;
 }

--- a/utils/convert-timestamp-human.ts
+++ b/utils/convert-timestamp-human.ts
@@ -1,0 +1,16 @@
+/** 
+ * `convertTimestamp` function takes in a timestamp as a string, and creates a 
+ * new `Date` object from it. It then extracts the month, day, and year from the 
+ * `Date` object, and formats them as a string in the desired format. 
+ *
+ * Note: `padStart()` method is used to ensure that the, month and day have 
+ * leading zeros when necessary.
+ */
+export function convertTimestamp(timestamp: string): string {
+  const date = new Date(timestamp);
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  const year = date.getFullYear().toString();
+  return `${month}/${day}/${year}`;
+}
+

--- a/utils/convert-timestamp-human.ts
+++ b/utils/convert-timestamp-human.ts
@@ -1,9 +1,9 @@
-/** 
- * `convertTimestamp` function takes in a timestamp as a string, and creates a 
- * new `Date` object from it. It then extracts the month, day, and year from the 
- * `Date` object, and formats them as a string in the desired format. 
+/**
+ * `convertTimestamp` function takes in a timestamp as a string, and creates a
+ * new `Date` object from it. It then extracts the month, day, and year from the
+ * `Date` object, and formats them as a string in the desired format.
  *
- * Note: `padStart()` method is used to ensure that the, month and day have 
+ * Note: `padStart()` method is used to ensure that the, month and day have
  * leading zeros when necessary.
  */
 export function convertTimestamp(timestamp: string): string {
@@ -13,4 +13,3 @@ export function convertTimestamp(timestamp: string): string {
   const year = date.getFullYear().toString();
   return `${month}/${day}/${year}`;
 }
-

--- a/utils/get-timestamp.ts
+++ b/utils/get-timestamp.ts
@@ -1,9 +1,8 @@
 /**
- * `getTimestamp` function creates a new Date object, which represents the 
- * current date and time, and calls its toISOString() method to return a string 
- * representation of the date and time in ISO 8601 format. 
+ * `getTimestamp` function creates a new Date object, which represents the
+ * current date and time, and calls its toISOString() method to return a string
+ * representation of the date and time in ISO 8601 format.
 */
 export function getTimestamp(): string {
   return new Date().toISOString();
 }
-

--- a/utils/get-timestamp.ts
+++ b/utils/get-timestamp.ts
@@ -1,3 +1,8 @@
+/**
+ * `getTimestamp` function creates a new Date object, which represents the 
+ * current date and time, and calls its toISOString() method to return a string 
+ * representation of the date and time in ISO 8601 format. 
+*/
 export function getTimestamp(): string {
   return new Date().toISOString();
 }


### PR DESCRIPTION
# Overview

The pull request includes several commits that add styling
and interactivity to an app, based on the given design.

- Adding a custom theme
- Fixing logo position and navbar
- Displaying human-readable note creation dates
- Adding a theme switcher
- Restyling markdown and preview headers
- Aligning sidebar labels
- Applying styles to borders and lists
- Optimizing performance
- Adding tooltips, with delay, on title and copy markdown btn
- Restyling blockquote pre code inline & blocks
- Scrolling pre code when overflow x
- Adding custom marker to list and shifting it inside
- Applying roboto family serif mono on preview and editor
- Coloring border orange when editor is focused
- Adding inline start border to main
- Fixing scroll on preview markdown overflow y axis
- Adding tooltips with delay on title and copy markdown btn

## Future Tasks (Optional)

- Add keyboard shortcuts for frequently used actions
- Implement search functionality for notes
- Allow users to sort notes by various criteria such as date, title, etc.
- Add support for multiple user accounts and authentication
- Enable users to add tags to their notes for better organization
- Implement a dark mode that can be toggled on and off
- Add the ability to attach files to notes
- Implement a feature that allows users to collaborate on notes with others
- Add a trash feature for deleted notes that can be restored if needed
- Implement a feature that suggests related notes based on keywords

## Changes

The commits demonstrate a comprehensive effort to enhance
the visual and interactive aspects of the app.

- style: add custom theme
- style: fix logo position and stretch navbar
- feat: use human readable note creation date in sidebar note
- feat: add theme switcher
- style: fix theme toggle positon & menu hover
- style: restyle headers of markdown and preview
- style: align sidebar 'my notes' label with headers
- style: color border orange when editor is focused
- style: add inline start border to main
- perf: pass forwardRef to button orange comp for tooltip
- style: add custom marker to list and shift it inside
- fix: scroll on preview markdown overflow y axis
- style: apply roboto family serif mono on preview and editor
- feat: style blockquote pre code inline & blocks
- style: scroll pre code when overflow x
- docs: add css comments
- style: fix pre and blockquote bg color in light theme
- feat: add tooltips with delay on title and copy markdown btn
